### PR TITLE
t/26.Report.Sender: add "use lib lib"

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -32,6 +32,7 @@ lib/Mail/DMARC/Report/Receive.pm
 lib/Mail/DMARC/Report/Send.pm
 lib/Mail/DMARC/Report/Send/HTTP.pm
 lib/Mail/DMARC/Report/Send/SMTP.pm
+lib/Mail/DMARC/Report/Sender.pm
 lib/Mail/DMARC/Report/Store.pm
 lib/Mail/DMARC/Report/Store/SQL.pm
 lib/Mail/DMARC/Report/Store/SQL/Grammars/MySQL.pm
@@ -40,6 +41,7 @@ lib/Mail/DMARC/Report/Store/SQL/Grammars/SQLite.pm
 lib/Mail/DMARC/Report/URI.pm
 lib/Mail/DMARC/Result.pm
 lib/Mail/DMARC/Result/Reason.pm
+lib/Mail/DMARC/Test/Transport.pm
 LICENSE
 Makefile.PL
 MANIFEST			This list of files
@@ -131,8 +133,8 @@ t/21.Report.Send.t
 t/22.Report.Send.SMTP.t
 t/23.Report.Send.HTTP.t
 t/25.Report.Receive.t
+t/26.Report.Sender.t
 t/mail-dmarc.ini
-t/travis/.travis.yml
 t/travis/backends/mail-dmarc.sql.mysql.ini
 t/travis/backends/mail-dmarc.sql.Pg.ini
 t/travis/backends/mail-dmarc.sql.SQLite.ini
@@ -140,4 +142,3 @@ t/whitelist
 TODO.md
 xt/author-critic.t
 xt/perlcritic.rc
-xt/release-pod-syntax.t

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ The list of dependencies appears long because of reporting. If this module is us
 
 Since DMARC is evolving, this implementation aims to be straight forward and easy to alter and extend. The programming style is primarily OO, which carries a small performance penalty but dividends in maintainability.
 
-When multiple options are available, such as when sending reports via SMTP or HTTP, calls should be made to the parent Send class, to broker the request. When storing reports, calls are made to the Store class, which dispatches to the SQL class. The idea is that if someone desired a data store other than the many provided by perl's DBI class, they could easily implement their own. If you do, please fork it on GitHub and share.
+When multiple options are available, such as when sending reports via SMTP or HTTP, calls should be made to the parent Send class to broker the request. When storing reports, calls are made to the Store class which dispatches to the SQL class. The idea is that if someone desired a data store other than those provided by perl's DBI class, they could easily implement their own. If you do, please fork it on GitHub and share.
 
 ## Fast
 
@@ -265,9 +265,7 @@ If you deploy this in an environment where performance is insufficient, please p
 
 2015-03 [RFC 7489](https://tools.ietf.org/html/rfc7489)
 
-Mar 30, 2012 Draft: http://www.dmarc.org/draft-dmarc-base-00-02.txt
-
-Best Current Practices: http://tools.ietf.org/html/draft-crocker-dmarc-bcp-03
+DMARC [Best Current Practices](http://tools.ietf.org/html/draft-crocker-dmarc-bcp-03)
 
 # HISTORY
 
@@ -282,13 +280,10 @@ The daddy of this perl module was a [DMARC module for the qpsmtpd MTA](https://g
 # CONTRIBUTORS
 
 - Benny Pedersen <me@junc.eu>
-- ColocateUSA.net <company@colocateusa.net>
 - Jean Paul Galea <jeanpaul@yubico.com>
 - Marisa Clardy <marisa@clardy.eu>
 - Priyadi Iman Nurcahyo <priyadi@priyadi.net>
-- Priyadi Iman Nurcahyo <priyadi@users.noreply.github.com>
 - Ricardo Signes <rjbs@cpan.org>
-- Ricardo Signes <rjbs@users.noreply.github.com>
 
 # COPYRIGHT AND LICENSE
 

--- a/lib/Mail/DMARC/Report/Sender.pm
+++ b/lib/Mail/DMARC/Report/Sender.pm
@@ -1,5 +1,5 @@
 package Mail::DMARC::Report::Sender;
-# VERSION
+
 use strict;
 use warnings;
 
@@ -13,7 +13,6 @@ use Email::Sender::Simple qw{ sendmail };
 use Email::Sender::Transport::SMTP;
 use Email::Sender::Transport::SMTP::Persistent;
 use Module::Load;
-#use XML::LibXML;
 
 sub new {
     my $class = shift;
@@ -180,9 +179,6 @@ sub run {
         my $transports_object = $package->new();
         $self->set_transports_object( $transports_object );
     }
-
-    #my $schema = 'http://dmarc.org/dmarc-xml/0.1/rua.xsd';
-    #my $xmlschema = XML::LibXML::Schema->new( location => $schema );
 
     local $SIG{'ALRM'} = sub{ die "timeout\n" };
 

--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -513,7 +513,6 @@ sub insert_policy_published {
     return 1;
 }
 
-my $memory_db;
 sub db_connect {
     my $self = shift;
 

--- a/t/26.Report.Sender.t
+++ b/t/26.Report.Sender.t
@@ -1,10 +1,12 @@
-#!/usr/bin/perl
-# VERSION
 use strict;
 use warnings;
 
 use Test::More;
+
+use lib 'lib';
 use Mail::DMARC::PurePerl;
+use Test::File::ShareDir
+  -share => { -dist => { 'Mail-DMARC' => 'share' } };
 
 use Mail::DMARC::Test::Transport;
 use Email::Sender::Transport::Failable;


### PR DESCRIPTION
this fixes most of the issue with the test failure. The only thing left is:

```sh
t/26.Report.Sender.t ......................... 
    #   Failed test '1 Email sent'
    #   at t/26.Report.Sender.t line 113.
    #          got: '0'
    #     expected: '1'

    #   Failed test 'Sent to correct address'
    #   at t/26.Report.Sender.t line 114.
    #          got: undef
    #     expected: 'rua@fastmaildmarc.com'
    # Looks like you failed 2 tests of 2.
t/26.Report.Sender.t ......................... 1/? 
#   Failed test 'method'
#   at t/26.Report.Sender.t line 120.
Can't use an undefined value as a SCALAR reference at t/26.Report.Sender.t line 115.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 255 just after 1.
t/26.Report.Sender.t ......................... Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 1/1 subtests 
```