### PR TITLE
A selector that has a falsey name is dropped

### DIFF
--- a/lib/Mail/DMARC/Report/Store/SQL.pm
+++ b/lib/Mail/DMARC/Report/Store/SQL.pm
@@ -513,7 +513,7 @@ sub insert_rr_dkim {
     my ( $self, $row_id, $dkim ) = @_;
     my (@fields, @values);
     foreach ( qw/ domain selector result human_result / ) {
-        next if ! $dkim->{$_};
+        next if ! defined $dkim->{$_};
         if ( 'domain' eq $_ ) {
             push @fields, 'domain_id';
             push @values, $self->get_domain_id( $dkim->{domain} );
@@ -537,7 +537,7 @@ sub insert_rr_spf {
     my ( $self, $row_id, $spf ) = @_;
     my (@fields, @values);
     for ( qw/ domain scope result / ) {
-        next if ! $spf->{$_};
+        next if ! defined $spf->{$_};
         if ( 'domain' eq $_ ) {
             push @fields, 'domain_id';
             push @values, $self->get_domain_id( $spf->{domain} );


### PR DESCRIPTION
As the FM branch and upstream have diverged this is a duplicate of the upstream MR
https://github.com/msimerson/mail-dmarc/pull/203